### PR TITLE
chore: Dependabot cooldown設定の追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: ""
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

npmサプライチェーン攻撃対策として、Dependabotのcooldown設定を追加します。

- 公開から7日未満のパッケージバージョンの自動更新PRを抑制
- セキュリティアップデートには影響しません（cooldownはバージョン更新のみに適用）

参考: https://qiita.com/masato_makino/items/516ca6f8a8b497131602