### PR TITLE
fix: vite 8 でビルドが通るよう修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,12 @@
       "devDependencies": {
         "@bunchtogether/vite-plugin-flow": "^1.0.0",
         "@types/file-saver": "^2.0.2",
-        "@types/node": "^17.0.25",
+        "@types/node": "^20.19.0",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
         "@vitejs/plugin-legacy": "^8.0.2",
         "sass": "^1.35.1",
+        "terser": "^5.16.0",
         "typescript": "^4.3.2",
         "vite": "^8.0.16"
       }
@@ -2051,7 +2052,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -2653,10 +2653,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
-      "devOptional": true
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
@@ -2755,7 +2759,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2914,8 +2917,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -4844,7 +4846,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "devOptional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4862,7 +4863,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -5020,7 +5020,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -5038,8 +5037,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
@@ -5097,6 +5095,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -6636,7 +6641,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -6917,10 +6921,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
-      "devOptional": true
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "devOptional": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/prop-types": {
       "version": "15.7.4",
@@ -6994,8 +7001,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "adler-32": {
       "version": "1.2.0",
@@ -7089,8 +7095,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "call-bind": {
       "version": "1.0.2",
@@ -8304,8 +8309,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
-      "peer": true
+      "devOptional": true
     },
     "source-map-js": {
       "version": "1.2.1",
@@ -8317,7 +8321,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8432,7 +8435,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -8444,8 +8446,7 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "devOptional": true,
-          "peer": true
+          "devOptional": true
         }
       }
     },
@@ -8489,6 +8490,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
   "devDependencies": {
     "@bunchtogether/vite-plugin-flow": "^1.0.0",
     "@types/file-saver": "^2.0.2",
-    "@types/node": "^17.0.25",
+    "@types/node": "^20.19.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@vitejs/plugin-legacy": "^8.0.2",
     "sass": "^1.35.1",
+    "terser": "^5.16.0",
     "typescript": "^4.3.2",
     "vite": "^8.0.16"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": false,
+    "types": [],
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
     })],
     base: '/keichan/',
     build: {
+        // vite 8 のデフォルトCSS minifier (lightningcss) は @blueprintjs/core@3 の
+        // 不正なセレクタ (`::after.bp3-active` 等) を拒否してビルドが失敗するため、
+        // 従来どおり esbuild を CSS minifier として使う。
+        cssMinify: 'esbuild',
         rollupOptions: {
           input: {
             // need a better way to template


### PR DESCRIPTION
## 原因（vite 8 由来）

vite を 8.0.16 にメジャー更新した結果、ローカルで `npm run build` が失敗していました。原因は3点です。

1. **peer 依存競合**: ルートが `@types/node@^17` を固定していたが、vite 8 は `@types/node@^20.19.0 || >=22.12.0` を要求するため `npm install` が ERESOLVE で失敗。
2. **terser 欠落**: `@vitejs/plugin-legacy@8` が `terser@^5.16.0` を peerDependency として要求するが、`terser` が devDependencies に存在しなかった。
3. **lightningcss が不正セレクタを拒否（本丸）**: vite 8 の新しい CSS minifier（lightningcss）が `@blueprintjs/core@3.47.0` の不正なセレクタ（`::after.bp3-active` など、擬似要素の後ろにクラス）を拒否してビルドが失敗。

## 行った修正

- `package.json`: `@types/node` を `^20.19.0` に更新（vite 8 の peer 要件を満たす）。`terser@^5.16.0` を devDependencies に追加。
- `tsconfig.json`: `"types": []` を追加。TypeScript 4.3 が解釈できない新しい `@types/node` のグローバル型定義（構文エラー TS1005 等）を読み込まないようにするため。ブラウザ向けの `./src` は node のグローバル型を必要としないため挙動への影響はなし。
- `vite.config.ts`: `build.cssMinify` を `'esbuild'` に設定し、lightningcss を回避。これにより blueprint の不正セレクタによるビルド失敗を回避。

いずれも最小・安全側の変更で、アプリの挙動を変える改変は行っていません。

## 動作確認

- `npm install` が ERESOLVE なしで成功することを確認。
- ローカルで `npm run build` が成功することを確認（exit 0、`dist/` に成果物を出力）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)