### PR TITLE
fix(ci): GitHub ホストランナーへ切り替え（self-hosted が稼働しておらず配信が止まっていた）

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -9,14 +9,11 @@ permissions:
 
 jobs:
   build-and-deploy:
-    runs-on: [self-hosted, Linux]
-    # runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v7
         with:
-          node-version: 16.3.0
-          always-auth: true
-          registry-url: https://registry.npmjs.org
+          node-version: 22
       - name: Checkout 🛎️
         uses: actions/checkout@v7.0.1
         with:


### PR DESCRIPTION
## 問題

このリポジトリのデプロイは **self-hosted ランナーで動かない状態**でした。本日分だけで5件以上の実行が `queued` のまま滞留しています。

```
08-01 12:00  queued  Merge pull request #56
08-01 10:52  queued  Merge pull request #49
08-01 10:52  queued  Merge pull request #48
08-01 10:52  queued  Merge pull request #47
08-01 10:49  queued  Merge pull request #55
08-01 08:07  queued  chore(deps): bump typescript...
```

リポジトリに登録されている self-hosted ランナーは **0台**です。つまり**マージしても配信されません**。

## 変更内容

**① GitHub ホストランナーへ切り替え**

```diff
-    runs-on: [self-hosted, Linux]
-    # runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
```

コメントアウトされていた `ubuntu-latest` を有効にした形です。

**② Node を 16.3.0 → 22 へ**

```diff
-          node-version: 16.3.0
-          always-auth: true
-          registry-url: https://registry.npmjs.org
+          node-version: 22
```

これは切り替えに**必須**です。

- Node 16 は **2023年9月に EOL**
- このリポジトリの `vite ^8.0.16` は **Node 20 以上を要求**するため、16 系ではビルドが通りません

`always-auth` / `registry-url` も外しました。依存はすべて公開パッケージ（`@blueprintjs/core`、`@vitejs/*` など）で、private レジストリ認証は使っていないためです。self-hosted 環境の `.npmrc` に依存していた可能性があるので、その前提を切っておきます。

## 確認してほしいこと

- **self-hosted ランナーを意図的に使っていたか**。ビルドに社内リソース（内部ネットワーク、ライセンス等）が必要な構成であれば、この変更は戻す必要があります。ワークフローの内容（`npm ci` と `vite build` のみ）からは、そうした依存は見当たりませんでした
- マージ後の初回ビルドが Node 22 で通るか。`typescript ^4.3.2` と組み合わせているため、型チェック（`tsc`）で警告が出る可能性があります

## 補足

このリポジトリはまだ gh-pages ブランチ方式です。ランナーが動くようになってから、公式 Action 方式への移行を別 PR で出します（他8リポジトリで移行済み）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
