### PR TITLE
chore(ci): GitHub Pages の配信を公式 Action 方式へ移行

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,15 +1,30 @@
 name: Build and Deploy
+
+# GitHub Pages への配信。gh-pages ブランチを経由せず、公式 Action で
+# ビルド成果物を直接 Pages へ渡す。
+#
+# 前提: リポジトリ設定 Settings → Pages → Source が "GitHub Actions" であること。
+# "Deploy from a branch" のままだと、このワークフローは成功しても公開内容が
+# 更新されない（古い gh-pages の内容が配信され続ける）。
 # 作業ブランチへの push で本番へ配信されないよう、対象を既定ブランチに限定する
 on:
   push:
     branches: ["main"]
 
-permissions:
-  contents: write
+permissions: {}
+
+# 配信が同時に走らないよう直列化する
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # configure-pages が Pages サイトの情報を取得するために必要
+      pages: read
     steps:
       - uses: actions/setup-node@v7
         with:
@@ -17,17 +32,32 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v7.0.1
         with:
-          # JamesIves の deploy action は自前で GITHUB_TOKEN を使うため、
-          # checkout 側に資格情報を残す必要がない（他リポジトリで動作確認済み）
+          # 配信は artifact 経由で行うため、checkout の資格情報は使わない
           persist-credentials: false
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
 
       - name: Install and Build 🔧
         run: |
           npm ci --ignore-scripts
           npm run build
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          branch: gh-pages
-          folder: dist/
+          path: dist/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write      # Pages へ配信する
+      id-token: write   # 配信元を検証する OIDC トークンの発行
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 何をする PR か

GitHub Pages への配信を **gh-pages ブランチ経由から公式 Action 方式へ**移行します。

```diff
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@<SHA> # v4.8.0
-        with:
-          branch: gh-pages
-          folder: dist/
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      ...
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: dist/
+
+  deploy:
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v5
```

ビルド手順（`npm ci --ignore-scripts` / `npm run build`）とランナー（`ubuntu-latest` / Node 22）は変えていません。

## なぜ

| 観点 | 現状 | 移行後 |
|---|---|---|
| 依存 | サードパーティ Action（個人アカウント提供） | **GitHub 公式のみ** |
| 必要な権限 | `contents: write` | `pages: read/write` + `id-token: write` |
| gh-pages ブランチ | 必要 | **不要** |

CALIL org でこの移行を進めており、これで **公式方式 19 : gh-pages ブランチ方式 2** になります。

## ⚠️ マージ後に設定変更が必要

**Settings → Pages → Source を `GitHub Actions` に変更**します。マージ時に私が API で切り替え、サイトが更新されるところまで確認します。

## 検証済み

8リポジトリで移行を完了し、すべてデプロイ成功を確認しています。`configure-pages` に `pages: read` が必要な点も反映済みです。

なお #57 でランナーを `ubuntu-latest` に切り替えたことで、このリポジトリの配信は正常に動くようになっています（それ以前は self-hosted 待ちで18件が滞留していました）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
