### PR TITLE
chore(deps): react/react-dom のメジャー更新を Dependabot の対象から除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,17 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 30
+    ignore:
+      # react のメジャー更新は周辺ライブラリの対応状況をまとめて確認してから
+      # 手動で判断する。詳細は Todoist を参照
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         patterns:


### PR DESCRIPTION
react 19 化は周辺ライブラリの対応状況次第でビルドを壊す(keichan で実際に react 19 化を誤ってマージしビルドが壊れた前例あり)。CALIL org 横断で対応状況をまとめて確認してから手動で判断するため、Dependabot が個別に major PR を作らないようにする。既存の react/react-dom/@types/react/@types/react-dom の major PR は次回の Dependabot 実行時に自動でクローズされる想定。