### PR TITLE
refactor(style): 非推奨の Sass @import を @use へ置き換える

### DIFF
--- a/src/index.sass
+++ b/src/index.sass
@@ -1,29 +1,9 @@
-@font-face
-  font-family: 'Conv_OCRB'
-  src: url('/keichan/fonts/OCRB.eot')
-  src: url('/keichan/fonts/OCRB.woff') format("woff"), url('/keichan/fonts/OCRB.ttf') format("truetype"), url('/keichan/fonts/OCRB.svg') format("svg")
-  font-weight: normal
-  font-style: normal
-
-*
-    box-sizing: border-box
-    margin: 0
-    padding: 0
-
-html, body
-    width: 100%
-    height: 100%
-    font-family: "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ Pro W3", "Noto Sans JP", "ＭＳ Ｐゴシック", "Helvetica Neue", "Helvetica", "Arial", sans-serif
-
-#app
-    height: 100%
-
- 
-@import "sass/index"
-@import "sass/_placeholder"
-@import "sass/suggest"
-// @import "sass/speech"
-// @import "sass/chat"
-// @import "sass/suggests"
-// @import "sass/new"
-// @import "sass/debug"
+@use 'sass/base'
+@use 'sass/index'
+@use 'sass/placeholder'
+@use 'sass/suggest'
+// @use 'sass/speech'
+// @use 'sass/chat'
+// @use 'sass/suggests'
+// @use 'sass/new'
+// @use 'sass/debug'

--- a/src/sass/_base.sass
+++ b/src/sass/_base.sass
@@ -1,0 +1,23 @@
+// index.sass にあった全体向けの定義。
+// @use は他の規則より前に置く必要があるため、index.sass を @use の一覧にし、
+// 中身をここへ移した。読み込み順は元の @import と同じ（これが最初）。
+
+@font-face
+  font-family: 'Conv_OCRB'
+  src: url('/keichan/fonts/OCRB.eot')
+  src: url('/keichan/fonts/OCRB.woff') format("woff"), url('/keichan/fonts/OCRB.ttf') format("truetype"), url('/keichan/fonts/OCRB.svg') format("svg")
+  font-weight: normal
+  font-style: normal
+
+*
+    box-sizing: border-box
+    margin: 0
+    padding: 0
+
+html, body
+    width: 100%
+    height: 100%
+    font-family: "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ Pro W3", "Noto Sans JP", "ＭＳ Ｐゴシック", "Helvetica Neue", "Helvetica", "Arial", sans-serif
+
+#app
+    height: 100%


### PR DESCRIPTION
## なぜ

Dart Sass は `@import` を非推奨にしており、**Dart Sass 3.0 で削除**される。
今もビルド時に DEPRECATION WARNING が出ている。

CALIL org 全体では31リポジトリ・247行が該当し、うち active は17リポジトリ・193行。
このPRはその一部。

## どう直したか

`@use` は「他の規則より前」に置く必要があるという制約がある。
末尾の `@import` を素直に `@use` へ書き換えると、**モジュールの CSS が
その配置位置ではなく先頭に出る**ため、読み込み順（カスケード）が入れ替わる。

```sass
// @import を末尾に置いた場合         // @use を先頭に置いた場合
.own                                 .from-part
  color: blue                          color: red
@import 'part'                       .own
// => .own が先、.from-part が後       //   color: blue
                                     // => 順序が逆になる
```

そこで **エントリを `@use` の一覧にし、エントリ自身が持っていた規則を
partial へ移す**ことで、元の出力順をそのまま保っている。
## このリポジトリでの変更

- `src/index.sass` の全体向けの規則（`@font-face` / `*` / `html, body` / `#app`）を
  `src/sass/_base.sass` へ移した
- `src/index.sass` は `@use` 4行だけになった。コメントアウトされている行も
  `@use` 表記に揃えた（`sass/chat` など元から存在しないファイルを指しているものは
  そのまま残している）

出力 CSS は 10746 bytes で移行前と一致。

なお `src/sass/index.sass` 249行目の `.linkedData` が空の規則で
`WARNING: This selector doesn't have any properties` が出るが、これは移行前から
出ているもので今回は触っていない。
## 確認したこと

- sass 1.102.0 でコンパイルした CSS が移行前と **SHA256 まで一致**
- `@import` の DEPRECATION WARNING が出なくなった

🤖 Generated with [Claude Code](https://claude.com/claude-code)
