### PR TITLE
chore(deps): isbn-utils を isbn3 に移行する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "file-saver": "^2.0.5",
         "howler": "^2.2.4",
-        "isbn-utils": "^1.1.0",
+        "isbn3": "^2.0.10",
         "jsbarcode": "^3.12.3",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -1333,13 +1333,18 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isbn-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/isbn-utils/-/isbn-utils-1.1.0.tgz",
-      "integrity": "sha512-IrWfYWHqRficGId19f3d6h0zTdBYp/jToRcg/0LVLtonSR+sIxj+chWb9qdQAN3WYydMmHTtKDvTqeUO4XyzAA==",
-      "license": "Apache-2.0",
+    "node_modules/isbn3": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.10.tgz",
+      "integrity": "sha512-9t4GRv6ETpWrW+y8tjmME5xg/sZHrKgo1EVkEvIAjJrJzT8+k211xklOCi6pfJIonHPjSS/ec1MoUeiowxStkQ==",
+      "license": "MIT",
+      "bin": {
+        "isbn": "bin/isbn",
+        "isbn-audit": "bin/isbn-audit",
+        "isbn-checksum": "bin/isbn-checksum"
+      },
       "engines": {
-        "node": ">=0.6"
+        "node": ">= 6.4.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "file-saver": "^2.0.5",
     "howler": "^2.2.4",
-    "isbn-utils": "^1.1.0",
+    "isbn3": "^2.0.10",
     "jsbarcode": "^3.12.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/prototype/new/App.tsx
+++ b/prototype/new/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 
 import { Button, Intent, Spinner, Card, Elevation, Tag, Icon, InputGroup, FormGroup, Overlay } from "@blueprintjs/core";
 
-import isbn_utils from 'isbn-utils'
+import ISBN from 'isbn3'
 
 import api from '../../src/api'
 import normalize_isbn from '../../src/normalize_isbn.js'
@@ -201,8 +201,8 @@ const App = () => {
                         tags: [],
                     }
                     book.bibHash = getBibHash(book)
-                    let i = isbn_utils.parse(normalize_isbn(book.isbn))
-                    book.isbn = i.asIsbn13()
+                    const i = ISBN.parse(normalize_isbn(book.isbn))
+                    book.isbn = i.isbn13
                     const openBDBooks = await getOpenBD([book.isbn])
                     // console.log(openBDBooks)
                     if (openBDBooks[0] !== null) {
@@ -242,10 +242,10 @@ const App = () => {
                                 pubdate = Number(book.pubdate.split('/')[0].split('.')[0])
                             }
                         }
-                        let i = isbn_utils.parse(normalize_isbn(book.isbn))
+                        const i = ISBN.parse(normalize_isbn(book.isbn))
                         let isbn = null
                         try {
-                            isbn = i.asIsbn13()
+                            isbn = i.isbn13
                         } catch {
                         }
                         if (isbn) {

--- a/prototype/suggest/App.tsx
+++ b/prototype/suggest/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 
 import { Button, Intent, Spinner, Card, Elevation, Tag, Icon, InputGroup, FormGroup } from "@blueprintjs/core";
 
-import isbn_utils from 'isbn-utils'
+import ISBN from 'isbn3'
 
 import api from '../../src/api'
 import normalize_isbn from '../../src/normalize_isbn.js'
@@ -74,8 +74,8 @@ const App = (props) => {
                 if (data.count >= 1) {
                     apiInstance.kill()
                     const book = data.books[0]
-                    let i = isbn_utils.parse(normalize_isbn(book.isbn))
-                    book.isbn = i.asIsbn13()
+                    const i = ISBN.parse(normalize_isbn(book.isbn))
+                    book.isbn = i.isbn13
                     resolve(book)
                 } else if (data.running === false && data.count === 0) {
                     reject()
@@ -107,10 +107,10 @@ const App = (props) => {
                             pubdate = Number(book.pubdate.split('/')[0].split('.')[0])
                         }
                     }
-                    let i = isbn_utils.parse(normalize_isbn(book.isbn))
+                    const i = ISBN.parse(normalize_isbn(book.isbn))
                     let isbn = null
                     try {
-                        isbn = i.asIsbn13()
+                        isbn = i.isbn13
                     } catch {
                     }
                     if (isbn) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import SearchForm from './SearchForm';
 import { getBook, getBooks, getBibHash } from './getBooks'
 
 import normalize_isbn from './normalize_isbn'
-import isbn_utils from 'isbn-utils'
+import ISBN from 'isbn3'
 
 let safetyUrlAudio = new Howl({
     src: ['./audio/safety.mp3'],
@@ -307,8 +307,8 @@ const App = () => {
             const lastRow = tempList[tempList.length - 1]
             // 最後の行にISBNが設定されているか？
             if (lastRow && !lastRow.isbn) {
-                let i = isbn_utils.parse(isbn10)
-                if (i) lastRow.isbn = i.asIsbn13()
+                const i = ISBN.parse(isbn10)
+                if (i) lastRow.isbn = i.isbn13
                 // console.log(tempList)
                 setRowList(tempList)
             } else {
@@ -511,7 +511,7 @@ const App = () => {
         }
         // ISBNのバリデーション
         if (book.isbn !== '') {
-            const isbn = isbn_utils.parse(book.isbn)
+            const isbn = ISBN.parse(book.isbn)
             if (isbn===null) {
                 alertAndLog('ISBNが不正です')
                 return errorAudio.play()

--- a/src/Suggest.jsx
+++ b/src/Suggest.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import ISBN from 'isbn-utils';
+import ISBN from 'isbn3';
 import api from './api';
 import {getOpenBD} from './getBooks';
 import SuggestBook from './SuggestBook';
@@ -42,10 +42,10 @@ const Suggest = ({ query, region, queryInput, open }) => {
                     book.isbn = book.isbn.replace(/-/g, '');
                     let isbn = ISBN.parse(book.isbn);
                     if (isbn) {
-                        book.isbn = isbn.asIsbn13();
+                        book.isbn = isbn.isbn13;
                     } else {
                         isbn = ISBN.parse(book.id);
-                        if (isbn) book.isbn = isbn.asIsbn13();
+                        if (isbn) book.isbn = isbn.isbn13;
                     }
                     newBooks.push(book);
                 } else {

--- a/src/getBooks.ts
+++ b/src/getBooks.ts
@@ -1,4 +1,4 @@
-import isbn_utils from 'isbn-utils'
+import ISBN from 'isbn3'
 import api from './api'
 import normalize_isbn, {normalize_isbn13} from './normalize_isbn'
 
@@ -97,9 +97,10 @@ export const getBooks = async (targetBook, region) => {
                             pubdate = Number(book.pubdate.split('/')[0].split('.')[0])
                         }
                     }
-                    let i = isbn_utils.parse(normalize_isbn(book.isbn))
+                    const normalizedIsbn = normalize_isbn(book.isbn)
+                    const i = normalizedIsbn ? ISBN.parse(normalizedIsbn) : null
                     let isbn = null
-                    if (i) isbn = i.asIsbn13()
+                    if (i) isbn = i.isbn13
                     if (isbn) {
                         books.push({
                             'title': book.title + ' ' + book.volume,

--- a/src/normalize_isbn.ts
+++ b/src/normalize_isbn.ts
@@ -1,28 +1,15 @@
-import isbn_utils from 'isbn-utils';
+import ISBN from 'isbn3';
 
 // ISBNをなるべく10桁に統一する
 // 不正なISBNの場合はfalseを返す
 function normalize_isbn(isbn) {
     isbn = isbn.normalize('NFKC').toUpperCase().replace(/[^0-9X]/g, '');
-    let i = isbn_utils.parse(isbn);
-    if (i) {
-        if (i.isIsbn10()) {
-            return i.asIsbn10();
-        } else if (i.isIsbn13()) {
-            let s = i.asIsbn13();
-            if (s.startsWith('978')) {
-                return i.asIsbn10();
-            } else {
-                return i.asIsbn13();
-            }
-        }
-    } else {
-        let i2 = isbn_utils.parse('978' + isbn);
-        if (i2 && i2.isIsbn13()) {
-            return i2.asIsbn10();
-        }
+    const parsed = ISBN.parse(isbn) ?? ISBN.parse('978' + isbn);
+    if (!parsed) {
+        return false;
     }
-    return false;
+    // 979始まりのISBN13は10桁に変換できないので、isbn10を持たない
+    return parsed.isbn10 ?? parsed.isbn13;
 }
 
 export default normalize_isbn;
@@ -32,13 +19,6 @@ export default normalize_isbn;
 // 不正なISBNの場合はfalseを返す
 export const normalize_isbn13 = (isbn) => {
     isbn = isbn.normalize('NFKC').toUpperCase().replace(/[^0-9X]/g, '');
-    let i = isbn_utils.parse(isbn);
-    if (i) {
-        if (i.isIsbn10()) {
-            return i.asIsbn13();
-        } else if (i.isIsbn13()) {
-            return i.asIsbn13();
-        }
-    }
-    return false;
+    const parsed = ISBN.parse(isbn);
+    return parsed ? parsed.isbn13 : false;
 }


### PR DESCRIPTION
## 背景

api-openurl の Dependabot 対応をしていて、ISBN の正規化に使っている `isbn-utils` の範囲データが古く、現行の割当に追いつけていないことが分かりました。[api-openurl#11](https://github.com/CALIL/api-openurl/pull/11) で先行して isbn3 へ移行済みです。

`isbn-utils` の `parse` はチェックデジットだけでなく、グループ・出版者記号が割当済みの範囲に入っていることも見ています。この範囲データが古いままで、2020年から流通している `979-8`（洋書のペーパーバックや KDP）などが通りません。`isbn3` は毎月 CI で isbn-international.org から範囲データを取り直しており、`isbn-utils` の範囲を完全な上位集合として含みます（グループ記号 227 → 287、isbn-utilsにしかないグループは0）。

## 変更内容

このリポジトリは `isbn-utils` を6箇所（`prototype/new/App.tsx`、`prototype/suggest/App.tsx`、`src/App.tsx`、`src/getBooks.ts`、`src/normalize_isbn.ts`、`src/Suggest.jsx`）で使っており、すべて `isbn3` に統一しました。

`isbn3` はメソッドを持つオブジェクトではなくプレーンオブジェクトを返すため、`isIsbn10()` / `asIsbn13()` のようなメソッド呼び出しを `isbn10` / `isbn13` プロパティの読み取りに書き換えています。

```ts
// normalize_isbn.ts
const parsed = ISBN.parse(isbn) ?? ISBN.parse('978' + isbn);
if (!parsed) {
    return false;
}
// 979始まりのISBN13は10桁に変換できないので、isbn10を持たない
return parsed.isbn10 ?? parsed.isbn13;
```

`src/getBooks.ts` では `normalize_isbn` の戻り値が `string | false` のため、`isbn3` の型定義（引数に `string` を要求）に合わせて false の場合は `parse` を呼ばないようガードを追加しています（`isbn-utils` には型定義が無く、これまで型検査を素通りしていました）。

## 確認したこと

- `npm run build`（`tsc && vite build`）がグリーン

このリポジトリの `gh-pages.yaml` は `on: push: branches: ["main"]` のみが起点で、PRではビルドが検証されません。上記のビルド確認はローカルで実施したものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)