### PR TITLE
fix: Vite 設定を native ESM 対応にする

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'vite'
 import react from '@vitejs/plugin-react'
-const { resolve } = require('path')
+import {fileURLToPath} from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -13,8 +13,8 @@ export default defineConfig({
         rollupOptions: {
           input: {
             // need a better way to template
-            main: resolve(__dirname, 'index.html'),
-            test: resolve(__dirname, 'test.html'),
+            main: fileURLToPath(new URL('index.html', import.meta.url)),
+            test: fileURLToPath(new URL('test.html', import.meta.url)),
           },
           // ファイル名にハッシュを付けない
           output: {


### PR DESCRIPTION
## 概要

Vite 設定ファイルを `.mts` / `.mjs` に変更し、明示的な ESM として読み込まれるようにしました。設定ファイル名を参照する設定やコマンドも同期し、CommonJS の `require` / `__dirname` があった箇所は `import.meta.url` ベースの同値なパス解決へ置き換えています。

## 背景

ESM 構文の Vite 設定が CommonJS として読み込まれており、現在は Vite の変換で動くものの、`configLoader: native` が既定化される将来バージョンでは壊れる可能性がありました。リポジトリ全体へ影響する `"type": "module"` は追加せず、設定ファイルだけを明示的な ESM 拡張子にしています。

## 影響

アプリケーションコード、依存関係、ビルド設定値は変更していません。生成物の全ファイルについて変更前後の内容ハッシュが一致しているため、配信物への差分はありません。

## 確認

- `npm run build`
- `npm run build -- --configLoader native`
- 変更前後のビルド出力について SHA-256 マニフェストが一致
