### PR TITLE
ci: @types/node のメジャー更新を Dependabot の対象から外す

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,14 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react-dom"
         update-types: ["version-update:semver-major"]
+      # @types/node のメジャーは Node.js 本体のメジャーに対応しているので、
+      # 実行環境（.github/workflows/gh-pages.yaml の node-version = 22）より
+      # 先に上げてはいけない。上げると新しい Node.js で追加された API を
+      # tsc が通してしまい、本番で初めて落ちる。
+      # Node.js を上げるときに node-version と一緒に手で上げる。
+      # 現状は 26 系が入っていて実行環境と乖離している（是正は別途）。
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         patterns:


### PR DESCRIPTION
## 何を変えるか

`.github/dependabot.yml` の npm エコシステムに、`@types/node` のメジャー更新を
無視する ignore を1件追加します。minor / patch はこれまでどおり届きます。

## なぜ

`@types/node` のメジャーは Node.js 本体のメジャーに対応しています。実行環境より
先に型だけが上がると、その Node.js にはまだ無い API を tsc が通してしまい、
本番で初めて落ちます。Node.js を上げるときに実行環境の指定と一緒に手で上げる運用にします。

- 実行環境: **Node.js 22**（`.github/workflows/gh-pages.yaml` の `node-version: 22`）
- 現在の `@types/node`: `^26.1.2`

> [!NOTE]
> 現在の `@types/node` は既に 26 系で、実行環境と乖離しています。この PR は
> 「これ以上先へ行かない」ようにするもので、乖離そのものの是正は含みません。

## 先例に合わせています

`ajime` / `haika2` / `web-cover` で同じ抑制を先に入れており、書式はそれに揃えました。
CALIL/unitrad-kintone-plugin#59（`@types/node` を 22.20.1 → 26.1.1 に上げる PR）が
出たのをきっかけに、同じ構成のリポジトリへ横展開しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
