### PR TITLE
chore(deps): @types/node を実行環境の Node.js 22 に合わせる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,6 @@ updates:
       # 先に上げてはいけない。上げると新しい Node.js で追加された API を
       # tsc が通してしまい、本番で初めて落ちる。
       # Node.js を上げるときに node-version と一緒に手で上げる。
-      # 現状は 26 系が入っていて実行環境と乖離している（是正は別途）。
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
     groups:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@types/file-saver": "^2.0.7",
-        "@types/node": "^26.1.2",
+        "@types/node": "^22.20.1",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "sass": "^1.102.0",
@@ -747,13 +747,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/react": {
@@ -1994,9 +1994,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/file-saver": "^2.0.7",
-    "@types/node": "^26.1.2",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "sass": "^1.102.0",


### PR DESCRIPTION
## 何を変えるか

`@types/node` を 26 系から **22.20.1** へ下げ、実行環境の Node.js に合わせます。

## なぜ

`@types/node` のメジャーは Node.js 本体のメジャーに対応します。このリポジトリが実際に
動かすのは **Node.js 22**（`.github/workflows/gh-pages.yaml` の `node-version: 22`）ですが、型だけが 26 系に先行していました。

この状態だと Node.js 26 で追加された API を tsc が通してしまい、実行環境にその API が
無いため本番で初めて落ちます。**ビルドもテストも通るので気づけません。**

## 検証

- `npm run build`（`tsc && vite build`）

いずれも通っています。26 の型に依存したコードはありませんでした。

あわせて `dependabot.yml` の「26 系が入っていて乖離している」という注記を落とします（#75 で入れたもの）。

## 背景

#75 で Dependabot のメジャー抑制を入れましたが、抑制は「これ以上先へ行かない」ように
するだけで、既に上がってしまった分は戻りません。その是正です。同じ乖離が11リポジトリに
あり、まとめて直しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)