### PR TITLE
fix(deps): nanoid を 3.3.18 へ更新する (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,9 +2200,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## 何を直すか

`nanoid` を 3.3.17 から **3.3.18** へ更新します。`package-lock.json`（package-lock.json）のみの変更で、`package.json` は触っていません。

## なぜ

| | |
|---|---|
| 脆弱性 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)（high・CVSS 5.9） |
| 内容 | `size` に 0 を渡したときカスタムジェネレータが無限ループする |
| 影響 | `< 3.3.18`（2026-08-13 の advisory 更新で `< 3.3.17` から広がった） |
| 修正版 | `3.3.18` |

**3.3.17 は修正版ではなくなりました。** 2026-08-08 の横断対応では 3.3.17 を修正版として扱っていましたが、その後 advisory が更新され、3.3.17 も影響範囲に入りました。このリポジトリでは Dependabot アラート [#55](https://github.com/CALIL/keichan/security/dependabot/55) が open になっています。

## Dependabot では直らない

`postcss` 経由の推移的依存で、`package.json` に宣言行がないため Dependabot は PR を作れません。postcss の要求レンジは `^3.3.16` なので、lockfile を更新するだけで解消し、メジャー更新も peer 依存の変更も発生しません。

CALIL org の active な npm リポジトリを横断確認したところ、**16 リポジトリ・17 マニフェスト**が 3.3.17 のまま残っていました。うち Dependabot アラートが発火していたのは 8 件だけです。同じ内容の PR を 16 リポジトリへ出しています。

## 確認したこと

- diff が `package-lock.json` の `nanoid` エントリだけに閉じていること（3	3	package-lock.json）
- `lockfileVersion` が変わっていないこと
- JSON として妥当であること
- 更新後の lockfile に `nanoid < 3.3.18` が残っていないこと
- `npm audit --package-lock-only` で `nanoid` が消えたこと

`resolved` / `integrity` は npm registry の `nanoid@3.3.18` から取得した値です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
